### PR TITLE
Update Venice defaults to current model catalog

### DIFF
--- a/netlify/functions/venice.ts
+++ b/netlify/functions/venice.ts
@@ -1,5 +1,5 @@
-const VENICE_API_KEY = "ntmhtbP2fr_pOQsmuLPuN_nm6lm2INWKiNcvrdEfEC";
-const VENICE_API_URL = "https://api.venice.ai/api/v1/responses";
+const VENICE_API_KEY = "n191pxahjwAE5VU5I8TmcPvPbKHJx0Z55VXToBj0kI";
+const VENICE_API_URL = "https://api.venice.ai/api/v1/chat/completions";
 
 type NetlifyEvent = {
   httpMethod: string;


### PR DESCRIPTION
## Summary
- replace the hard-coded Venice API key with the latest value provided by the user
- switch the default vision model to mistral-31-24b and attach venice_parameters when calling the chat completions endpoint so the Venice system prompt is included

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f35c5b3f4c833188eb5cc9be2efdf5